### PR TITLE
QuestionListItem과 질문 상세 페이지를 링크

### DIFF
--- a/components/QuestionList.tsx
+++ b/components/QuestionList.tsx
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 import QuestionListItem from './QuestionListItem';
+import {QuestionModel} from '../types/model';
+import {getAllQuestions} from './lib/questions';
+import {useEffect, useState} from 'react';
 
 const Container = styled.div`
   /*Layout 적용 이후 width, margin 변경 요망* */
@@ -10,15 +13,28 @@ const Container = styled.div`
   background-color: var(--white-yellow);
 `;
 
+export function QuestionListItems({data}) {
+  const listData = data;
+  console.log('json???: ', listData[0]);
+
+  const listItems = listData.map(item => (
+    <QuestionListItem questionData={item} />
+  ));
+  return <Container>{listItems}</Container>;
+}
+
 export default function QuestionList() {
-  return (
-    <Container>
-      <QuestionListItem />
-      <QuestionListItem />
-      <QuestionListItem />
-      <QuestionListItem />
-      <QuestionListItem />
-      <QuestionListItem />
-    </Container>
-  );
+  const [questionsList, setQuestionsList] = useState<Array<QuestionModel>>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await getAllQuestions();
+      console.log('getAllQuestions: ', data);
+      setQuestionsList(data.data);
+    };
+
+    fetchData();
+  });
+
+  return <QuestionListItems data={questionsList} />;
 }

--- a/components/QuestionListItem.tsx
+++ b/components/QuestionListItem.tsx
@@ -1,5 +1,7 @@
+import Link from 'next/link';
 import styled from 'styled-components';
 import Questioner from './Questioner';
+import {QuestionModel} from '../types/model';
 
 const Container = styled.div`
   width: 100%;
@@ -8,6 +10,9 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: 30px;
+  :hover {
+    cursor: pointer;
+  }
 `;
 
 const Title = styled.div`
@@ -16,11 +21,18 @@ const Title = styled.div`
   font-weight: 600;
 `;
 
-export default function QuestionListItem() {
+interface Props {
+  questionData: QuestionModel;
+}
+
+export default function QuestionListItem({questionData}: Props) {
+  const link = '/questions/' + questionData.id;
   return (
-    <Container>
-      <Questioner />
-      <Title>이게 궁금해용</Title>
-    </Container>
+    <Link href={link}>
+      <Container>
+        <Questioner />
+        <Title>{questionData.title}</Title>
+      </Container>
+    </Link>
   );
 }

--- a/components/lib/questions.tsx
+++ b/components/lib/questions.tsx
@@ -24,3 +24,37 @@ export async function getQuestionDetailData(
     lastModifiedAt: '2021-01-10T12:32:22',
   };
 }
+
+export async function getAllQuestions() {
+  //TODO axios를 이용하여 질문 리스트를 가져와야 한다.
+
+  const data = [
+    {
+      id: 1,
+      title: '1번 질문의 제목입니다.',
+      contents: '1번 질문의 내용입니다.',
+      responderId: null,
+      createdAt: '2021-01-10',
+      lastModifiedAt: '2021-01-10T12:32:22',
+    },
+    {
+      id: 2,
+      title: '2번 질문의 제목입니다.',
+      contents: '2번 질문의 내용입니다.',
+      responderId: null,
+      createdAt: '2021-01-10',
+      lastModifiedAt: '2021-01-10T12:33:33',
+    },
+    {
+      id: 3,
+      title: '3번 질문의 제목입니다.',
+      contents: '3번 질문의 내용입니다.',
+      responderId: null,
+      createdAt: '2021-01-10',
+      lastModifiedAt: '2021-01-10T12:33:33',
+    },
+  ];
+  console.log('getAllQuestions: ', data);
+
+  return {data};
+}


### PR DESCRIPTION
- 메인에 표시할 질문 리스트를 가져오는 getAllQuestions() 을 만들었습니다. (예시데이터 반환. to do : axios 연결)
- QuestionList가 질문리스트를 가져오며 렌더되도록 바꿨습니다. (axios 적용해도 바로 사용가능)
- QuestionListItem이 QuestionList 로부터 prop을 받아 title을 표시하도록 바꿨습니다. (이 부분 depth가 나중에 깊어질 수 있어 contextAPI 도입 등을 고려해봐야 할 것 같습니다.)